### PR TITLE
chore(PILOT-5): Add Android Studio launch support with fallback defaults

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,33 +1,24 @@
-# IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
+# PromptPilot Gradle Properties
 
 pluginGroup = com.github.egarcia.promptpilot
 pluginName = PromptPilot
 pluginRepositoryUrl = https://github.com/e-Garcia/PromptPilot
-# SemVer format -> https://semver.org
 pluginVersion = 0.0.1
 
-# Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
-pluginUntilBuild = 252.*
-
-# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformType = IC
-platformVersion = 2024.2.5
-
-# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
+# IntelliJ platform configuration (see build.gradle.kts for defaults)
+platformType = AI
+platformVersion = 243.24978.46
+platformSinceBuild = 243
+platformUntilBuild = 252.*
 platformPlugins =
-# Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
 
-# Gradle Releases -> https://github.com/gradle/gradle/releases
+# Gradle version
 gradleVersion = 8.13
 
-# Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
+# Kotlin stdlib opt-out (for plugins)
 kotlin.stdlib.default.dependency = false
 
-# Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
-org.gradle.configuration-cache = true
-
-# Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
+# Performance tuning
+distributionSha256Sum =
 org.gradle.caching = true
+org.gradle.configuration-cache = true


### PR DESCRIPTION
### 🔧 Summary

This PR enables PromptPilot to run directly in Android Studio using:
- Auto-detection of IDE install path (macOS, Windows, or ANDROID_STUDIO_HOME)
- Fallback platformType/platformVersion/platformPlugins if not set
- Gradle task `printIdeProfile` for introspection
- Sandbox configuration for isolated plugin testing

### 🧪 How to Test

```bash
./gradlew runIde -PideProfile=android
./gradlew printIdeProfile
