### PR TITLE
chore(deps): bump org.jetbrains.qodana from 2024.3.4 to 2025.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ changelog = "2.4.0"
 intelliJPlatform = "2.6.0"
 kotlin = "2.1.20"
 kover = "0.9.1"
-qodana = "2024.3.4"
+qodana = "2025.2.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
PR description

Updates the org.jetbrains.qodana Gradle plugin to 2025.2.1.

This keeps PromptPilot’s static analysis tooling current with the latest JetBrains Qodana release,
ensuring compatibility with modern IntelliJ platform builds and benefiting from new checks and fixes.

- Bumped from 2024.3.4 → 2025.2.1 in gradle/libs.versions.toml