### PR TITLE
feat(PILOT-50): add AI-aware output target selector

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,3 +6,5 @@ documentation:
   - docs/**
 feature:
   - feature/**
+refactor:
+  - refactor/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 # PromptPilot Changelog
 
-## [Unreleased]
+## Unreleased
+### Changed
+
+## 1.1.0
+### Added
+- AI Output Target dropdown supporting PromptPilot default, GitHub Copilot, Cursor, and custom destinations with auto-created directories/files.
+- ContextOutputTarget presets plus documentation in README explaining how to switch targets and re-enable JCEF when needed.
 
 ## 1.0.0
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Whether you're refining unit tests, generating patch files, or enforcing archite
 
 - 🔌 **Multi-AI Support** – Works with Gemini, OpenAI (GPT), Tabnine, and more.
 - 🧠 **Context-Aware Prompting** – Tailor instructions based on selected code, file name, or project structure.
+- 🗂️ **AI-Aware Output Destinations** – Send repo context to Copilot, Cursor, or custom paths with automatic directory creation.
 - 🧪 **Unit Test Generator** – Generate unit tests aligned with your team’s best practices.
 - 🔍 **Patch-Focused Prompts** – Suggest minimal diffs instead of rewriting whole files.
 - 🧱 **Pluggable Architecture** – Easily add new AI backends or customize logic.
@@ -34,13 +35,28 @@ To install manually:
 
 ## 🤖 Supported Backends
 
-| Backend             | Status            | Notes                               |
-|---------------------|-------------------|-------------------------------------|
+| Backend             | Status           | Notes                               |
+|---------------------|------------------|-------------------------------------|
 | **Gemini (Google)** | 🛠️ In development | Targeting second major version      |
-| **Copilot**         | 🛠️ In development | Targeting second major version      |
+| **Copilot**         | ✅ Completed      | v1.1.0                              |
 | **Cursor**          | 🛠️ In development | Targeting third major version       |
 | **OpenAI GPT-4**    | 🛠️ In development | Backend abstraction already planned |
-| **Tabnine**         | 🔜 Not started     | Under consideration                 |
+| **Tabnine**         | 🔜 Not started   | Under consideration                 |
+
+---
+
+## 🎯 AI Output Targets
+
+Use the **AI Output Target** dropdown in the PromptPilot tool window to control where the generated repository context file lives:
+
+| Target              | Destination Path                       | Notes                                              |
+|---------------------|----------------------------------------|----------------------------------------------------|
+| PromptPilot Default | `.promptpilot/repo-context.md`         | Safe default for any AI assistant                  |
+| GitHub Copilot      | `.github/copilot-instructions.md`      | Loaded auto-magically by Copilot                   |
+| Cursor              | `.cursor/rules`                        | Cursor parses this file for workspace guidelines   |
+| Custom              | Any directory + filename you specify   | Paths resolve relative to the project root         |
+
+PromptPilot auto-creates missing directories/files before writing. Switch targets, click **Save Output Target**, and generate again—the destination updates instantly.
 
 ---
 
@@ -84,4 +100,4 @@ We welcome contributions, issues, and feedback! See [CONTRIBUTING.md](CONTRIBUTI
 ## 🢁‍ Maintainer
 Developed and maintained by [Erick Garcia](https://github.com/e-Garcia).
 
-_Last updated: April 18, 2025_
+_Last updated: November 22, 2025_

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.egarcia.promptpilot
 pluginName = PromptPilot
 pluginRepositoryUrl = https://github.com/e-Garcia/PromptPilot
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.0
+pluginVersion = 1.1.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242

--- a/src/main/kotlin/com/github/egarcia/promptpilot/Constants.kt
+++ b/src/main/kotlin/com/github/egarcia/promptpilot/Constants.kt
@@ -3,6 +3,7 @@ package com.github.egarcia.promptpilot
 object SettingsKeys {
     const val PATCH_TOGGLE_KEY = "com.github.egarcia.promptpilot.patchFormatToggle"
     const val DEBUG_LAYOUT_KEY = "com.github.egarcia.promptpilot.debugLayout"
+    const val OUTPUT_TARGET_KEY = "promptpilot.output.target"
     const val CUSTOM_OUTPUT_DIR = "promptpilot.custom.output.dir"
     const val CUSTOM_OUTPUT_FILENAME = "promptpilot.custom.output.filename"
 }
@@ -11,6 +12,10 @@ object FileConstants {
     const val OUTPUT_DIR = ".promptpilot"
     const val SOURCE_CONTEXT_DIR = ".promptpilot/source-context"
     const val REPO_CONTEXT_FILENAME = "repo-context.md"
+    const val GITHUB_OUTPUT_DIR = ".github"
+    const val GITHUB_COPILOT_FILENAME = "copilot-instructions.md"
+    const val CURSOR_OUTPUT_DIR = ".cursor"
+    const val CURSOR_FILENAME = "rules"
     const val SAMPLE_CONTEXT_FILENAME = "sample-context.md"
     const val DEFAULT_NEW_FILE = "new-context-file.md"
     const val DEFAULT_FILE_EXTENSION = ".md"

--- a/src/main/kotlin/com/github/egarcia/promptpilot/file/ContextFileManager.kt
+++ b/src/main/kotlin/com/github/egarcia/promptpilot/file/ContextFileManager.kt
@@ -2,6 +2,7 @@ package com.github.egarcia.promptpilot.file
 
 import com.github.egarcia.promptpilot.FileConstants
 import com.github.egarcia.promptpilot.SettingsKeys
+import com.github.egarcia.promptpilot.file.ContextOutputTarget.Companion.fromId
 import com.github.egarcia.promptpilot.resources.MyBundle
 import com.github.egarcia.promptpilot.resources.Strings
 import com.intellij.ide.util.PropertiesComponent
@@ -20,24 +21,59 @@ class ContextFileManager(
     private val properties get() = PropertiesComponent.getInstance(project)
     private val localFS = LocalFileSystem.getInstance()
 
-    private val outputDir: File
-        get() = properties.getValue(SettingsKeys.CUSTOM_OUTPUT_DIR)
-            ?.let { Paths.get(basePath, it).toFile() }
-            ?: Paths.get(basePath, FileConstants.OUTPUT_DIR).toFile()
+    private val selectedTarget: ContextOutputTarget
+        get() {
+            val valueSet = properties.isValueSet(SettingsKeys.OUTPUT_TARGET_KEY)
+            val storedTarget = properties.getValue(SettingsKeys.OUTPUT_TARGET_KEY)?.let { fromId(it) }
+            if (storedTarget != null) return storedTarget
 
-    private val outputFilename: String
-        get() = properties.getValue(SettingsKeys.CUSTOM_OUTPUT_FILENAME)
-            ?: FileConstants.REPO_CONTEXT_FILENAME
+            if (!valueSet && hasCustomOverrides()) {
+                return ContextOutputTarget.CUSTOM
+            }
+            return ContextOutputTarget.PROMPT_PILOT
+        }
+
+    private fun hasCustomOverrides(): Boolean {
+        val customDir = properties.getValue(SettingsKeys.CUSTOM_OUTPUT_DIR)
+        val customFile = properties.getValue(SettingsKeys.CUSTOM_OUTPUT_FILENAME)
+        val dirDiffers = !customDir.isNullOrBlank() && customDir != FileConstants.OUTPUT_DIR
+        val fileDiffers = !customFile.isNullOrBlank() && customFile != FileConstants.REPO_CONTEXT_FILENAME
+        return dirDiffers || fileDiffers
+    }
+
+    private fun resolveOutputLocation(): OutputLocation {
+        val target = selectedTarget
+        val location = target.defaultLocation()
+        val relativeDir = when {
+            target.isCustom -> properties.getValue(SettingsKeys.CUSTOM_OUTPUT_DIR)?.takeUnless { it.isBlank() }
+                ?: FileConstants.OUTPUT_DIR
+            location != null -> location.relativeDir
+            else -> FileConstants.OUTPUT_DIR
+        }
+
+        val filename = when {
+            target.isCustom -> properties.getValue(SettingsKeys.CUSTOM_OUTPUT_FILENAME)?.takeUnless { it.isBlank() }
+                ?: FileConstants.REPO_CONTEXT_FILENAME
+            location != null -> location.filename
+            else -> FileConstants.REPO_CONTEXT_FILENAME
+        }
+
+        return OutputLocation(relativeDir, filename)
+    }
 
     fun ensureDirectoriesExist() {
+        val location = resolveOutputLocation()
+        var lastAttempted = FileConstants.SOURCE_CONTEXT_DIR
         runCatching {
-            if (!fsOps.exists(sourceDir)) fsOps.createDirectories(sourceDir.toPath())
-            if (!fsOps.exists(outputDir)) fsOps.createDirectories(outputDir.toPath())
+            ensureDirectoryExists(sourceDir)
+            lastAttempted = location.relativeDir
+            val outputDir = Paths.get(basePath, location.relativeDir).normalize().toFile()
+            ensureDirectoryExists(outputDir)
         }.onFailure { e ->
             throw IllegalStateException(
                 MyBundle.message(
                     Strings.ERROR_CREATING_OUTPUT_DIRECTORY,
-                    FileConstants.OUTPUT_DIR,
+                    lastAttempted,
                     e.message ?: MyBundle.message(Strings.ERROR_UNKNOWN)
                 )
             )
@@ -81,11 +117,12 @@ class ContextFileManager(
         isPatchFormatEnabled: Boolean
     ): Result<File> = runCatching {
         val repoFile = getOutputFile()
+        repoFile.parentFile?.let { ensureDirectoryExists(it) }
         var content = if (selectedFilesContent.isEmpty()) {
             MyBundle.message(
                 Strings.NO_FILES_SELECTED_MESSAGE,
                 FileConstants.SOURCE_CONTEXT_DIR,
-                outputFilename
+                repoFile.name
             )
         } else {
             selectedFilesContent.values.joinToString("\n").trimEnd()
@@ -129,12 +166,26 @@ class ContextFileManager(
             contents
         }
 
-    fun getOutputFile(): File = File(outputDir, outputFilename)
+    fun getOutputFile(): File {
+        val location = resolveOutputLocation()
+        val directory = Paths.get(basePath, location.relativeDir).normalize().toFile()
+        return File(directory, location.filename)
+    }
+
+    fun currentOutputTarget(): ContextOutputTarget = selectedTarget
+
+    fun currentOutputLocation(): OutputLocation = resolveOutputLocation()
 
     private fun sanitizeFileName(name: String): String {
         return name
             .replace(File.separatorChar, '_')
             .replace("..", "_")
             .replace(Regex(FileConstants.INVALID_FILENAME_REGEX), "_")
+    }
+
+    private fun ensureDirectoryExists(directory: File) {
+        if (!fsOps.exists(directory)) {
+            fsOps.createDirectories(directory.toPath())
+        }
     }
 }

--- a/src/main/kotlin/com/github/egarcia/promptpilot/file/ContextOutputTarget.kt
+++ b/src/main/kotlin/com/github/egarcia/promptpilot/file/ContextOutputTarget.kt
@@ -1,0 +1,63 @@
+package com.github.egarcia.promptpilot.file
+
+import com.github.egarcia.promptpilot.FileConstants
+import com.github.egarcia.promptpilot.resources.MyBundle
+import com.github.egarcia.promptpilot.resources.Strings
+
+/**
+ * Represents the location for output files.
+ *
+ * @property relativeDir The directory path for the output file. This is relative to the project root unless it is an absolute path.
+ *                       For preset targets, this should not be blank.
+ * @property filename The name of the output file. For preset targets, this should not be blank.
+ */
+data class OutputLocation(
+    val relativeDir: String,
+    val filename: String
+)
+
+enum class ContextOutputTarget(
+    val id: String,
+    private val labelKey: String,
+    private val defaultDir: String?,
+    private val defaultFilename: String?
+) {
+    PROMPT_PILOT(
+        id = "promptpilot",
+        labelKey = Strings.OUTPUT_TARGET_PROMPTPILOT_LABEL,
+        defaultDir = FileConstants.OUTPUT_DIR,
+        defaultFilename = FileConstants.REPO_CONTEXT_FILENAME
+    ),
+    GITHUB_COPILOT(
+        id = "github-copilot",
+        labelKey = Strings.OUTPUT_TARGET_GITHUB_COPILOT_LABEL,
+        defaultDir = FileConstants.GITHUB_OUTPUT_DIR,
+        defaultFilename = FileConstants.GITHUB_COPILOT_FILENAME
+    ),
+    CURSOR(
+        id = "cursor",
+        labelKey = Strings.OUTPUT_TARGET_CURSOR_LABEL,
+        defaultDir = FileConstants.CURSOR_OUTPUT_DIR,
+        defaultFilename = FileConstants.CURSOR_FILENAME
+    ),
+    CUSTOM(
+        id = "custom",
+        labelKey = Strings.OUTPUT_TARGET_CUSTOM_LABEL,
+        defaultDir = null,
+        defaultFilename = null
+    );
+
+    val displayName: String
+        get() = MyBundle.message(labelKey)
+
+    fun defaultLocation(): OutputLocation? =
+        if (defaultDir != null && defaultFilename != null) OutputLocation(defaultDir, defaultFilename) else null
+
+    val isCustom: Boolean
+        get() = this == CUSTOM
+
+    companion object {
+        fun fromId(id: String?): ContextOutputTarget =
+            entries.firstOrNull { it.id == id } ?: PROMPT_PILOT
+    }
+}

--- a/src/main/kotlin/com/github/egarcia/promptpilot/resources/StringKeys.kt
+++ b/src/main/kotlin/com/github/egarcia/promptpilot/resources/StringKeys.kt
@@ -22,6 +22,24 @@ object Strings {
     const val SAVE_OUTPUT_SETTINGS_BUTTON = "save.output.settings.button"
     @NonNls
     const val SAVE_OUTPUT_SETTINGS_SUCCESS = "success.save.output.settings"
+    @NonNls
+    const val OUTPUT_TARGET_LABEL = "output.target.label"
+    @NonNls
+    const val OUTPUT_TARGET_ACTIVE_PATH = "output.target.active.path"
+    @NonNls
+    const val OUTPUT_TARGET_STATUS_READY = "output.target.status.ready"
+    @NonNls
+    const val OUTPUT_TARGET_STATUS_MISSING = "output.target.status.missing"
+    @NonNls
+    const val OUTPUT_TARGET_PROMPTPILOT_LABEL = "output.target.promptpilot.label"
+    @NonNls
+    const val OUTPUT_TARGET_GITHUB_COPILOT_LABEL = "output.target.github.copilot.label"
+    @NonNls
+    const val OUTPUT_TARGET_CURSOR_LABEL = "output.target.cursor.label"
+    @NonNls
+    const val OUTPUT_TARGET_CUSTOM_LABEL = "output.target.custom.label"
+    @NonNls
+    const val OUTPUT_TARGET_CUSTOM_HINT = "output.target.custom.hint"
 
     @NonNls
     const val CUSTOM_OUTPUT_DIR_LABEL = "custom.output.dir.label"

--- a/src/main/kotlin/com/github/egarcia/promptpilot/toolWindow/PromptPilotToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/egarcia/promptpilot/toolWindow/PromptPilotToolWindowFactory.kt
@@ -3,18 +3,23 @@ package com.github.egarcia.promptpilot.toolWindow
 import com.github.egarcia.promptpilot.FileConstants
 import com.github.egarcia.promptpilot.SettingsKeys
 import com.github.egarcia.promptpilot.file.ContextFileManager
+import com.github.egarcia.promptpilot.file.ContextOutputTarget
+import com.github.egarcia.promptpilot.file.OutputLocation
 import com.github.egarcia.promptpilot.resources.Dimensions
 import com.github.egarcia.promptpilot.resources.MyBundle
 import com.github.egarcia.promptpilot.resources.Strings
 import com.intellij.icons.AllIcons
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.CollapsiblePanel
 import com.intellij.ui.JBColor
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
@@ -23,6 +28,7 @@ import com.intellij.util.ui.UIUtil
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.FlowLayout
+import java.nio.file.Paths
 import javax.swing.BorderFactory
 import javax.swing.Box
 import javax.swing.BoxLayout
@@ -31,6 +37,7 @@ import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.JTextField
 import javax.swing.UIManager
+import javax.swing.event.DocumentEvent
 import javax.swing.table.DefaultTableModel
 
 class PromptPilotToolWindowFactory : ToolWindowFactory {
@@ -58,17 +65,20 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
     }
 
     private fun createMainPanel(project: Project): JPanel {
+        val targetComboBox = createTargetComboBox()
+        val targetPickerPanel = createTargetPickerPanel(project, targetComboBox)
         val topSettingsPanel = createSettingsPanel(
             project,
             MyBundle.message(Strings.SETTINGS_LABEL),
             MyBundle.message(Strings.TOGGLE_PATCH_TEXT),
             MyBundle.message(Strings.CREATE_REPO_CONTEXT_BUTTON),
-            MyBundle.message(Strings.DELETE_REPO_CONTEXT_BUTTON)
+            MyBundle.message(Strings.DELETE_REPO_CONTEXT_BUTTON),
+            targetPickerPanel
         )
 
         val filesScrollPane = createFilesTablePanel(project)
         val fileActionsPanel = createFileActionsPanel(project)
-        val advancedSettingsPanel = createAdvancedOutputSettingsPanel(project) // ← NEW PANEL
+        val advancedSettingsPanel = createAdvancedOutputSettingsPanel(project, targetComboBox) // ← NEW PANEL
 
         val panel = JPanel()
         panel.layout = BoxLayout(panel, BoxLayout.Y_AXIS)
@@ -87,6 +97,35 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
         val outerPanel = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0))
         outerPanel.add(panel)
         return outerPanel
+    }
+
+    private fun createTargetComboBox(): ComboBox<ContextOutputTarget> {
+        return ComboBox(ContextOutputTarget.entries.toTypedArray()).apply {
+            renderer = SimpleListCellRenderer.create("") { item -> item?.displayName ?: "" }
+            selectedItem = fileManager.currentOutputTarget()
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+    }
+
+    private fun createTargetPickerPanel(
+        project: Project,
+        targetComboBox: ComboBox<ContextOutputTarget>
+    ): JPanel {
+        val panel = JPanel()
+        panel.layout = BoxLayout(panel, BoxLayout.Y_AXIS)
+        panel.alignmentX = Component.LEFT_ALIGNMENT
+
+        val label = JBLabel(MyBundle.message(Strings.OUTPUT_TARGET_LABEL))
+        label.alignmentX = Component.LEFT_ALIGNMENT
+
+        panel.add(label)
+        panel.add(Box.createVerticalStrut(Dimensions.SPACING_X_SMALL))
+        panel.add(targetComboBox)
+
+        if (isDebugLayoutEnabled(project)) panel.border =
+            BorderFactory.createLineBorder(JBColor.YELLOW)
+
+        return panel
     }
 
 
@@ -224,7 +263,8 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
         settingsLabelText: String,
         togglePatchText: String,
         createRepoContextButtonText: String,
-        deleteRepoContextButtonText: String
+        deleteRepoContextButtonText: String,
+        targetPickerPanel: JPanel
     ): JPanel {
         val topPanel = JPanel()
         topPanel.layout = BoxLayout(topPanel, BoxLayout.Y_AXIS)
@@ -253,6 +293,7 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
         }
 
         listOf(
+            targetPickerPanel, Box.createVerticalStrut(Dimensions.SPACING_SMALL),
             settingsLabel, Box.createVerticalStrut(Dimensions.SPACING_SMALL),
             togglePatch, Box.createVerticalStrut(Dimensions.SPACING_SMALL),
             createRepoContextButton, Box.createVerticalStrut(Dimensions.SPACING_SMALL),
@@ -348,7 +389,10 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
         return filesPanel
     }
 
-    private fun createAdvancedOutputSettingsPanel(project: Project): JPanel {
+    private fun createAdvancedOutputSettingsPanel(
+        project: Project,
+        targetComboBox: ComboBox<ContextOutputTarget>
+    ): JPanel {
         val properties = PropertiesComponent.getInstance(project)
 
         val customOutputDirField = JTextField(
@@ -357,6 +401,80 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
         val customOutputFileField = JTextField(
             properties.getValue(SettingsKeys.CUSTOM_OUTPUT_FILENAME, FileConstants.REPO_CONTEXT_FILENAME), 20
         )
+        val basePath = project.basePath ?: "."
+
+        val destinationLabel = JBLabel()
+        val destinationStatusLabel = JBLabel()
+        val customHintLabel = JBLabel(MyBundle.message(Strings.OUTPUT_TARGET_CUSTOM_HINT))
+        customHintLabel.foreground = UIUtil.getLabelDisabledForeground()
+
+        fun selectedTarget(): ContextOutputTarget =
+            targetComboBox.selectedItem as? ContextOutputTarget ?: ContextOutputTarget.PROMPT_PILOT
+
+        /**
+         * Resolve the active output location preview.
+         *
+         * Returns an [OutputLocation] describing the relative directory and filename
+         * for the current output target (including honoring custom overrides in project properties).
+         */
+        fun resolvePreviewLocation(): OutputLocation {
+            return fileManager.currentOutputLocation()
+        }
+
+        fun updateDestinationLabels() {
+            val (relativeDir, fileName) = resolvePreviewLocation()
+            destinationLabel.text = MyBundle.message(
+                Strings.OUTPUT_TARGET_ACTIVE_PATH,
+                relativeDir,
+                fileName
+            )
+            val dirFile = Paths.get(basePath, relativeDir).normalize().toFile()
+            if (dirFile.exists()) {
+                destinationStatusLabel.text = MyBundle.message(Strings.OUTPUT_TARGET_STATUS_READY)
+                destinationStatusLabel.foreground = UIUtil.getLabelForeground()
+            } else {
+                destinationStatusLabel.text =
+                    MyBundle.message(Strings.OUTPUT_TARGET_STATUS_MISSING, relativeDir)
+                destinationStatusLabel.foreground = JBColor.RED
+            }
+        }
+
+        fun updateCustomFieldState() {
+            val isCustom = selectedTarget().isCustom
+            customOutputDirField.isEnabled = isCustom
+            customOutputFileField.isEnabled = isCustom
+            customHintLabel.isVisible = isCustom
+        }
+
+        fun JTextField.onChange(block: () -> Unit) {
+            document.addDocumentListener(object : DocumentAdapter() {
+                override fun textChanged(e: DocumentEvent) {
+                    block()
+                }
+            })
+        }
+
+        // Debounced onChange to avoid excessive updates and file system checks
+        fun JTextField.debouncedOnChange(delayMs: Int = 300, block: () -> Unit) {
+            val clientKey = "promptpilot.debounce.timer"
+            this.onChange {
+                (this.getClientProperty(clientKey) as? javax.swing.Timer)?.stop()
+                val debounceTimer = javax.swing.Timer(delayMs) { _ ->
+                    block()
+                }.apply {
+                    isRepeats = false
+                    start()
+                }
+                this.putClientProperty(clientKey, debounceTimer)
+            }
+        }
+
+        customOutputDirField.debouncedOnChange { updateDestinationLabels() }
+        customOutputFileField.debouncedOnChange { updateDestinationLabels() }
+        targetComboBox.addActionListener {
+            updateCustomFieldState()
+            updateDestinationLabels()
+        }
 
         val saveButton = JButton(
             MyBundle.message(Strings.SAVE_OUTPUT_SETTINGS_BUTTON),
@@ -364,8 +482,17 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
         )
         saveButton.alignmentX = Component.LEFT_ALIGNMENT
         saveButton.addActionListener {
-            properties.setValue(SettingsKeys.CUSTOM_OUTPUT_DIR, customOutputDirField.text.trim())
-            properties.setValue(SettingsKeys.CUSTOM_OUTPUT_FILENAME, customOutputFileField.text.trim())
+            val target = selectedTarget()
+            properties.setValue(SettingsKeys.OUTPUT_TARGET_KEY, target.id)
+            if (target.isCustom) {
+                properties.setValue(SettingsKeys.CUSTOM_OUTPUT_DIR, customOutputDirField.text.trim())
+                properties.setValue(
+                    SettingsKeys.CUSTOM_OUTPUT_FILENAME,
+                    customOutputFileField.text.trim()
+                )
+            }
+            fileManager.ensureDirectoriesExist()
+            updateDestinationLabels()
             Messages.showInfoMessage(
                 project,
                 MyBundle.message(Strings.SAVE_OUTPUT_SETTINGS_SUCCESS),
@@ -376,13 +503,25 @@ class PromptPilotToolWindowFactory : ToolWindowFactory {
 
         val contentPanel = JPanel()
         contentPanel.layout = BoxLayout(contentPanel, BoxLayout.Y_AXIS)
+        val customDirLabel = JBLabel(MyBundle.message(Strings.CUSTOM_OUTPUT_DIR_LABEL))
+        val customFileLabel = JBLabel(MyBundle.message(Strings.CUSTOM_OUTPUT_FILE_LABEL))
+
         listOf(
             Box.createVerticalStrut(Dimensions.SPACING_X_SMALL),
-            JBLabel(MyBundle.message(Strings.CUSTOM_OUTPUT_DIR_LABEL)), customOutputDirField,
-            JBLabel(MyBundle.message(Strings.CUSTOM_OUTPUT_FILE_LABEL)), customOutputFileField,
+            destinationLabel,
+            destinationStatusLabel,
+            Box.createVerticalStrut(Dimensions.SPACING_X_SMALL),
+            customDirLabel,
+            customOutputDirField,
+            customFileLabel,
+            customOutputFileField,
+            customHintLabel,
             Box.createVerticalStrut(Dimensions.SPACING_X_SMALL),
             saveButton
-        ).forEach { contentPanel.add(it) }
+        ).forEach { component -> contentPanel.add(component) }
+
+        updateCustomFieldState()
+        updateDestinationLabels()
 
         val expandIcon: Icon = UIManager.getIcon("Tree.collapsedIcon") ?: UIUtil.getTreeCollapsedIcon()
         val collapseIcon: Icon = UIManager.getIcon("Tree.expandedIcon") ?: UIUtil.getTreeExpandedIcon()

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -1,17 +1,26 @@
 tool.window.title=Prompt Pilot
 
-settings.label=PromptPilot Settings
+settings.label=Repository Context Settings
+output.target.label=AI Repository Context Target:
+output.target.active.path=Writing to: {0}/{1}
+output.target.status.ready=Destination directory exists.
+output.target.status.missing=Directory ''{0}'' does not exist and will be created automatically.
+output.target.promptpilot.label=PromptPilot Default (.promptpilot/repo-context.md)
+output.target.github.copilot.label=GitHub Copilot (.github/copilot-instructions.md)
+output.target.cursor.label=Cursor (.cursor/rules)
+output.target.custom.label=Custom (choose directory + file in Advanced Output Settings)
+output.target.custom.hint=Custom paths are resolved relative to the project root unless absolute.
 custom.output.dir.label=Custom Output Directory:
 custom.output.file.label=Custom Output Filename:
 selected.column.label=Selected
 file.name.column.label=File Name
-files.label=Files in Source Context Directory ({0}}):
+files.label=Files in Source Context Directory ({0}):
 
 toggle.patch.button=Use Patch Output Format
 create.repo.context.button=Create/Update Repo Context
 delete.repo.context.button=Delete Repo Context
 add.new.source.file.button=Add New Source File
-save.output.settings.button=Save Output Settings
+save.output.settings.button=Save Output Target
 refresh.list.button=Refresh List
 
 new.source.file.dialog.title=New Source File Name
@@ -20,7 +29,7 @@ advanced.output.settings.title=Advanced Output Settings
 new.source.file.dialog.message=Enter the name for the new source file (e.g., my-feature.md):
 no.files.selected.message=// No files were selected from ''{0}''.\n// ''{1}'' is intentionally empty or will only contain patch instructions.
 
-success.save.output.settings=Custom output settings saved.
+success.save.output.settings=Output target saved.
 success.file.context.deleted=File: {0} deleted.
 success.file.context.generated=File: {0} has been generated/updated successfully with selected content.
 


### PR DESCRIPTION
• Summary

  - add an AI Repository Context Target selector to the PromptPilot tool window so contributors can route the generated repo-context file to .promptpilot, .github/copilot-instructions.md, .cursor/rules, or a custom location
  - persist the selected preset/custom paths in PropertiesComponent, auto-create missing directories/files, and expose a live destination preview/status in the UI
  - document the workflow in README.md, AGENTS.md, and CLAUDE.md, plus add ContextOutputTarget.kt to define the presets

  Details

  - ContextFileManager now resolves output paths via ContextOutputTarget, creates directories on demand, and exposes helper accessors (currentOutputTarget, currentOutputLocation)
  - PromptPilotToolWindowFactory adds the dropdown, custom fields, hint text, save button behavior, and live status labels
  - new constants/string resources for preset names, Copilot/Cursor filenames, and output-target messaging

  Testing
  - Pick an AI provider from the dropdown, select one or more files inside of the source context directory and create or update repo context file. Validate that the proper file was created and it being referenced by the AI tool in any new conversations.


<img width="1026" height="736" alt="Screenshot 2025-11-22 at 11 12 00 AM" src="https://github.com/user-attachments/assets/d19d89ee-83ba-498e-b0cd-bc70125c35c6" />

  - Closes #50.